### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,12 @@
 {
     "name": "base64id"
   , "version": "0.1.0"
+  , "licenses" : [
+        {
+            "type" : "MIT",
+            "url" : "https://github.com/caolan/async/raw/master/LICENSE"
+        }
+    ]
   , "description": "Generates a base64 id"
   , "author": "Kristian Faeldt <faeldt_kristian@cyberagent.co.jp>"
   , "repository": {


### PR DESCRIPTION
Allows license to be read programatically.