### PR TITLE
fix(buffer): replace deprecated Buffer constructor usage

### DIFF
--- a/lib/base64id.js
+++ b/lib/base64id.js
@@ -78,7 +78,7 @@ Base64Id.prototype.getRandomBytes = function(bytes) {
  */
 
 Base64Id.prototype.generateId = function () {
-  var rand = new Buffer(15); // multiple of 3 for base64
+  var rand = Buffer.alloc(15); // multiple of 3 for base64
   if (!rand.writeInt32BE) {
     return Math.abs(Math.random() * Math.random() * Date.now() | 0).toString()
       + Math.abs(Math.random() * Math.random() * Date.now() | 0).toString();

--- a/package.json
+++ b/package.json
@@ -9,5 +9,5 @@
       , "url": "https://github.com/faeldt/base64id.git"
    }
   , "main": "./lib/base64id.js"
-  , "engines": { "node": ">= 0.4.0" }
+  , "engines": { "node": "^4.5.0 || >= 5.9" }
 }


### PR DESCRIPTION
See: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

Let me know if compatibility with older NodeJS versions is important. Then I would propose a new PR with the appropriate polyfill.